### PR TITLE
Fix failed to execute script error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,15 +36,15 @@ jobs:
         run: |
           uv sync --frozen
 
-      # 5. Install PyInstaller
+      # 5. Install PyInstaller in uv environment
       - name: Install PyInstaller
         run: |
-          uv pip install --system pyinstaller
+          uv pip install pyinstaller
 
       # 6. Build Windows executable
       - name: Build executable
         run: |
-          pyinstaller --onefile --windowed --name="CaisleanGaofar" main.py
+          uv run pyinstaller --onefile --windowed --name="CaisleanGaofar" main.py
 
       # 7. Create GitHub Release and Upload Asset
       - name: Create Release and Upload Asset


### PR DESCRIPTION
The executable was failing with "no module named pygame" because:
- PyInstaller was installed globally with --system flag
- pygame was installed in uv's virtual environment
- PyInstaller couldn't find pygame in the system Python

Solution:
- Install PyInstaller in the same uv environment as dependencies
- Run PyInstaller with 'uv run' to use the correct environment

This fixes the script execution error where the built .exe couldn't find pygame.