### PR TITLE
Adjust game items and starting inventory

### DIFF
--- a/chest.py
+++ b/chest.py
@@ -132,7 +132,6 @@ class Chest:
                 health_bonus=100,
             ),
             # Misc
-            Item("Gold Coin", ItemType.MISC, "A shiny coin"),
             Item("Ancient Key", ItemType.MISC, "Opens something?"),
             Item("Magic Scroll", ItemType.MISC, "Mysterious writings"),
         ]

--- a/game.py
+++ b/game.py
@@ -682,10 +682,17 @@ class Game:
             description="A simple woolen tunic",
             defense_bonus=1,
         )
+        health_potion = Item(
+            name="Health Potion",
+            item_type=ItemType.CONSUMABLE,
+            description="Restores 30 HP",
+            health_bonus=30,
+        )
 
         # Equip starting items (they'll auto-equip to appropriate slots)
         self.warrior.inventory.add_item(short_sword)
         self.warrior.inventory.add_item(woolen_tunic)
+        self.warrior.inventory.add_item(health_potion)
 
         # Player starts with 0 gold (default)
 

--- a/loot_table.py
+++ b/loot_table.py
@@ -68,6 +68,17 @@ def create_misc_item(name: str, description: str, gold_value: int = 0) -> Item:
     return Item(name, ItemType.MISC, description, gold_value=gold_value)
 
 
+def create_gold_drop(min_amount: int, max_amount: int) -> Item:
+    """Create a gold drop item with random amount."""
+    amount = random.randint(min_amount, max_amount)
+    return Item(
+        name=f"{amount} Gold",
+        item_type=ItemType.MISC,
+        description=f"{amount} pieces of gold",
+        gold_value=amount,
+    )
+
+
 # Monster-specific loot tables
 LOOT_TABLES = {
     "banshee": LootTable(
@@ -76,14 +87,14 @@ LOOT_TABLES = {
                 create_common_armor("Spectral Veil", defense_bonus=8, health_bonus=15),
                 0.3,
             ),
-            (create_consumable("Tear of Sorrow", health_bonus=25), 0.4),
-            (create_misc_item("Ethereal Echo", "A haunting whisper from beyond"), 0.5),
+            (create_consumable("Tear of Sorrow", health_bonus=25), 0.6),
+            (create_gold_drop(1, 5), 0.5),
         ]
     ),
     "leprechaun": LootTable(
         [
             (create_common_weapon("Lucky Shillelagh", attack_bonus=12), 0.4),
-            (create_misc_item("Gold Coin", "A shiny golden coin", gold_value=1), 0.8),
+            (create_gold_drop(5, 15), 0.9),
             (create_misc_item("Four-Leaf Clover", "Brings good fortune"), 0.3),
         ]
     ),
@@ -94,7 +105,8 @@ LOOT_TABLES = {
                 create_common_armor("Shadow Pelt", defense_bonus=10, health_bonus=20),
                 0.3,
             ),
-            (create_consumable("Dark Berry", health_bonus=30), 0.5),
+            (create_consumable("Dark Berry", health_bonus=30), 0.7),
+            (create_gold_drop(2, 6), 0.5),
         ]
     ),
     "selkie": LootTable(
@@ -105,8 +117,8 @@ LOOT_TABLES = {
                 ),
                 0.4,
             ),
-            (create_consumable("Ocean Pearl", health_bonus=40), 0.3),
-            (create_misc_item("Sea Shell", "Echoes with ocean sounds"), 0.6),
+            (create_consumable("Ocean Pearl", health_bonus=40), 0.6),
+            (create_gold_drop(2, 7), 0.5),
         ]
     ),
     "dullahan": LootTable(
@@ -118,21 +130,21 @@ LOOT_TABLES = {
                 ),
                 0.3,
             ),
-            (create_misc_item("Spine Whip", "A fearsome trophy"), 0.35),
+            (create_gold_drop(5, 12), 0.6),
         ]
     ),
     "changeling": LootTable(
         [
             (create_common_weapon("Fae Dagger", attack_bonus=18), 0.35),
-            (create_consumable("Glamour Essence", health_bonus=35), 0.4),
-            (create_misc_item("Fairy Dust", "Shimmers with magic"), 0.5),
+            (create_consumable("Glamour Essence", health_bonus=35), 0.65),
+            (create_gold_drop(3, 8), 0.5),
         ]
     ),
     "clurichaun": LootTable(
         [
             (create_common_weapon("Drunken Bottle", attack_bonus=14), 0.4),
-            (create_consumable("Fine Whiskey", health_bonus=45), 0.6),
-            (create_misc_item("Silver Flask", "Never seems to empty"), 0.3),
+            (create_consumable("Fine Whiskey", health_bonus=45), 0.75),
+            (create_gold_drop(4, 10), 0.65),
         ]
     ),
     "merrow": LootTable(
@@ -142,24 +154,25 @@ LOOT_TABLES = {
                 0.35,
             ),
             (create_common_weapon("Trident Shard", attack_bonus=20), 0.3),
-            (create_consumable("Sea Kelp", health_bonus=28), 0.5),
+            (create_consumable("Sea Kelp", health_bonus=28), 0.7),
+            (create_gold_drop(3, 9), 0.5),
         ]
     ),
     "fear_gorta": LootTable(
         [
-            (create_consumable("Blessed Bread", health_bonus=50), 0.5),
+            (create_consumable("Blessed Bread", health_bonus=50), 0.7),
             (
                 create_common_armor("Tattered Robes", defense_bonus=6, health_bonus=10),
                 0.4,
             ),
-            (create_misc_item("Famine Token", "A grim reminder"), 0.3),
+            (create_gold_drop(1, 4), 0.4),
         ]
     ),
     "cat_si": LootTable(
         [
             (create_common_weapon("Cat's Claw", attack_bonus=16), 0.4),
             (create_common_armor("Fur Mantle", defense_bonus=9, health_bonus=18), 0.35),
-            (create_misc_item("White Star Mark", "Symbol of the Cat Sidhe"), 0.4),
+            (create_gold_drop(2, 6), 0.5),
         ]
     ),
 }


### PR DESCRIPTION
- Add health potion to player starting inventory
- Increase health potion drop rates across all monsters (0.6-0.75 range)
- Remove gold coin items from chest generation
- Replace gold coin items with random gold drops in loot tables
- Add random gold drops to all monsters (1-15 gold based on monster type)
- Leprechauns now drop 5-15 gold with 90% drop rate
- Other monsters drop varying amounts of gold (1-12) with 40-65% rates