### PR TITLE
Fix skills selection dropdown issue

### DIFF
--- a/src/caislean_gaofar/core/game.py
+++ b/src/caislean_gaofar/core/game.py
@@ -146,7 +146,7 @@ class Game:
 
     def handle_events(self):
         """Handle pygame events."""
-        # Use event dispatcher for most event handling
+        # Use event dispatcher for all event handling
         self.event_dispatcher.handle_events(
             warrior=self.warrior,
             game_state_manager=self.state_manager,
@@ -155,6 +155,7 @@ class Game:
             inventory_ui=self.renderer.inventory_ui,
             shop=self.shop,
             shop_ui=self.renderer.shop_ui,
+            skill_ui=self.skill_ui,
             dungeon_manager=self.dungeon_manager,
             on_restart=self.restart,
             on_save=self.save_game,
@@ -165,15 +166,6 @@ class Game:
             on_shop_check=self._handle_shop_check,
             inventory_game_ref=self,
         )
-
-        # Handle skill UI input separately (skills screen)
-        for event in pygame.event.get():
-            if self.state_manager.state == config.STATE_SKILLS:
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    if event.button == 1:  # Left click - learn skill
-                        self.skill_ui.handle_click(event.pos, self.warrior, False)
-                    elif event.button == 3:  # Right click - set active
-                        self.skill_ui.handle_click(event.pos, self.warrior, True)
 
     def restart(self):
         """Restart the game."""

--- a/src/caislean_gaofar/utils/event_dispatcher.py
+++ b/src/caislean_gaofar/utils/event_dispatcher.py
@@ -9,6 +9,7 @@ from caislean_gaofar.entities.entity_manager import EntityManager
 from caislean_gaofar.ui.inventory_ui import InventoryUI
 from caislean_gaofar.objects.shop import Shop
 from caislean_gaofar.ui.shop_ui import ShopUI
+from caislean_gaofar.ui.skill_ui import SkillUI
 from caislean_gaofar.core import config
 
 
@@ -30,6 +31,7 @@ class EventDispatcher:
         inventory_ui: InventoryUI,
         shop: Shop,
         shop_ui: ShopUI,
+        skill_ui: SkillUI,
         dungeon_manager,
         on_restart: Callable,
         on_save: Callable,
@@ -51,6 +53,7 @@ class EventDispatcher:
             inventory_ui: The inventory UI
             shop: The shop instance
             shop_ui: The shop UI
+            skill_ui: The skill UI
             dungeon_manager: The dungeon manager
             on_restart: Callback for restarting the game
             on_save: Callback for saving the game
@@ -95,6 +98,14 @@ class EventDispatcher:
             # Handle shop input when shop is open
             if game_state_manager.state == config.STATE_SHOP:
                 shop_ui.handle_input(event, shop, warrior)
+
+            # Handle skill UI input when skills screen is open
+            if game_state_manager.state == config.STATE_SKILLS:
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    if event.button == 1:  # Left click - learn skill
+                        skill_ui.handle_click(event.pos, warrior, False)
+                    elif event.button == 3:  # Right click - set active
+                        skill_ui.handle_click(event.pos, warrior, True)
 
     def _handle_keydown(
         self,

--- a/tests/utils/test_event_dispatcher.py
+++ b/tests/utils/test_event_dispatcher.py
@@ -10,6 +10,7 @@ from caislean_gaofar.entities.entity_manager import EntityManager
 from caislean_gaofar.ui.inventory_ui import InventoryUI
 from caislean_gaofar.objects.shop import Shop
 from caislean_gaofar.ui.shop_ui import ShopUI
+from caislean_gaofar.ui.skill_ui import SkillUI
 from caislean_gaofar.core import config
 
 
@@ -742,6 +743,73 @@ class TestEventDispatcher:
         mocks["on_use_return_portal"].assert_not_called()
         mocks["turn_processor"].queue_player_action.assert_not_called()
 
+    @patch("pygame.event.get")
+    def test_skill_ui_handle_left_click(self, mock_get_events):
+        """Test that skill UI receives left click events."""
+        # Arrange
+        dispatcher = EventDispatcher()
+
+        click_event = Mock()
+        click_event.type = pygame.MOUSEBUTTONDOWN
+        click_event.button = 1  # Left click
+        click_event.pos = (100, 200)
+        mock_get_events.return_value = [click_event]
+
+        mocks = self._create_mock_parameters()
+        mocks["game_state_manager"].state = config.STATE_SKILLS
+
+        # Act
+        dispatcher.handle_events(**mocks)
+
+        # Assert
+        mocks["skill_ui"].handle_click.assert_called_once_with(
+            (100, 200), mocks["warrior"], False
+        )
+
+    @patch("pygame.event.get")
+    def test_skill_ui_handle_right_click(self, mock_get_events):
+        """Test that skill UI receives right click events."""
+        # Arrange
+        dispatcher = EventDispatcher()
+
+        click_event = Mock()
+        click_event.type = pygame.MOUSEBUTTONDOWN
+        click_event.button = 3  # Right click
+        click_event.pos = (150, 250)
+        mock_get_events.return_value = [click_event]
+
+        mocks = self._create_mock_parameters()
+        mocks["game_state_manager"].state = config.STATE_SKILLS
+
+        # Act
+        dispatcher.handle_events(**mocks)
+
+        # Assert
+        mocks["skill_ui"].handle_click.assert_called_once_with(
+            (150, 250), mocks["warrior"], True
+        )
+
+    @patch("pygame.event.get")
+    def test_skill_ui_handle_middle_click(self, mock_get_events):
+        """Test that skill UI ignores middle mouse button clicks."""
+        # Arrange
+        dispatcher = EventDispatcher()
+
+        click_event = Mock()
+        click_event.type = pygame.MOUSEBUTTONDOWN
+        click_event.button = 2  # Middle click
+        click_event.pos = (150, 250)
+        mock_get_events.return_value = [click_event]
+
+        mocks = self._create_mock_parameters()
+        mocks["game_state_manager"].state = config.STATE_SKILLS
+
+        # Act
+        dispatcher.handle_events(**mocks)
+
+        # Assert - should not be called for middle click
+        mocks["skill_ui"].handle_click.assert_not_called()
+
     def _create_mock_parameters(self):
         """Create mock parameters for handle_events method."""
         warrior = Mock(spec=Warrior)
@@ -766,6 +834,7 @@ class TestEventDispatcher:
         inventory_ui = Mock(spec=InventoryUI)
         shop = Mock(spec=Shop)
         shop_ui = Mock(spec=ShopUI)
+        skill_ui = Mock(spec=SkillUI)
         dungeon_manager = Mock()
 
         return {
@@ -776,6 +845,7 @@ class TestEventDispatcher:
             "inventory_ui": inventory_ui,
             "shop": shop,
             "shop_ui": shop_ui,
+            "skill_ui": skill_ui,
             "dungeon_manager": dungeon_manager,
             "on_restart": Mock(),
             "on_save": Mock(),


### PR DESCRIPTION
The issue was caused by duplicate event processing. The EventDispatcher was consuming all pygame events via pygame.event.get(), leaving the event queue empty when game.py tried to handle skill UI events.

Changes:
- Added skill_ui parameter to EventDispatcher.handle_events()
- Moved skill UI event handling into EventDispatcher (lines 102-108)
- Removed redundant event handling from game.py handle_events()
- Added comprehensive tests for skill UI click handling
- Maintained 100% branch coverage

Skills can now be selected with left-click (learn) and right-click (set active) in the 'C' menu as intended.