### PR TITLE
Show defense stat next to attack in HUD

### DIFF
--- a/src/caislean_gaofar/ui/ui_constants.py
+++ b/src/caislean_gaofar/ui/ui_constants.py
@@ -48,17 +48,17 @@ class UIConstants:
 
     # XP Panel
     XP_PANEL_HEIGHT = 60
-    XP_PANEL_Y = 390
+    XP_PANEL_Y = 470
     XP_BAR_HEIGHT = 18
     XP_BAR_Y_OFFSET = 30
 
     # Inventory Panel
     INVENTORY_PANEL_HEIGHT = 60
-    INVENTORY_PANEL_Y = 470
+    INVENTORY_PANEL_Y = 540
 
     # Skills Panel
     SKILLS_PANEL_HEIGHT = 60
-    SKILLS_PANEL_Y = 530
+    SKILLS_PANEL_Y = 610
 
     # ===== Shop Panel Constants =====
     # Reasoning: These define the shop UI layout and sizing


### PR DESCRIPTION
Reorganized HUD panel positions to fix overlap issue where the XP panel was obscuring the defense panel. Defense now appears immediately after attack in the visual hierarchy.

Changes:
- Moved XP panel from Y=390 to Y=470 (after defense)
- Moved Inventory panel from Y=470 to Y=540
- Moved Skills panel from Y=530 to Y=610
- Defense panel remains at Y=400, now properly visible

This ensures the HUD panels follow a logical visual order matching the rendering sequence, with defense appearing right next to attack as intended.

Resolves #108 